### PR TITLE
(borarachar) remove antigo Founder

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@
 
 ## Bora Rachar
 **Organização**: [BoraRachar](https://github.com/orgs/BoraRachar/repositories)  
-**Founder**: [Danrley Senegalha Pires](https://www.linkedin.com/in/dansenpir)  
+**Founder**: []()  
 **Descrição do projeto**: Plataforma web e mobile que servirá de intermediadora de rateios.  
     
 <hr/>


### PR DESCRIPTION
Me remove como Founder do projeto BoraRachar, cargo que não possuo há bastante tempo.

Não sei dizer quem é o Founder atual, portanto deve ser informado posteriormente pelo atual time BoraRachar.