### PR TITLE
Adição projeto Amigos dos Animais

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [DeliveryAPP](#deliveryapp)
 - [MoradaApp](#moradaapp)
 - [Trilha Desenvolviemento XP](#trilha-desenvolvimento-xp)
+- [Amigos dos Animais](#amigosdosanimais)
 
 <hr/>
 
@@ -139,3 +140,10 @@ utilizado, proporcionando novas experiências ao usuário.
 **Organização**: [Trilha Desenvolvimento XP](https://github.com/TrilhaDesenvolvimento-XP)  
 **Founder**: [Gabriela Queiroz](https://www.linkedin.com/in/gabiqassis/)  
 **Descrição do projeto**: Uma plataforma que oferece oportunidades desde iniciante ao avançado na aréa de tecnologia, disponibilizando projetos reais de varios niveis e prazos definidos com acesso ao um time de desenvolvimento, recrutamento para o mesmo e orientação de mentores da plataforma. 
+
+<hr/>
+
+## Amigos dos Animais
+**Organização**: [Amigos dos Animais](https://github.com/amigosdosanimais)  
+**Founder**: [Frederico Espeschit](https://www.linkedin.com/in/fredericoespeschit/)  
+**Descrição do projeto**: A plataforma Ada ajuda organizações não governamentais que cuidam dos animais a gerenciar todas as suas atividades. Ela permite centralizar e controlar todas as informações importantes.


### PR DESCRIPTION
O projeto Ada agora faz parte da lista de projetos ativos da soujunior-labs. Para facilitar o trabalho da equipe, foi estabelecida uma organização. Dentro dessa organização, há um repositório chamado .github. Lá, você pode encontrar a licença GPL 3.0 e a tag da soujunior-labs. Além disso, há um README para a página principal da organização Amigos dos Animais.